### PR TITLE
Altera seeds do LDAP para refletir o banco

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -14,9 +14,11 @@ DB_PASS=spa2
 DB_NAME=spa2_local
 # Caminho do log
 LOG_PATH=~/log/spa2
-#LDAP
+
+# Conexão LDAP
 LDAP_URL=ldap://localhost:389
-OUS=ou=Usuarios,dc=cmc,dc=pr,dc=gov,dc=br
+OUS=ou=usuarios,dc=cmc,dc=pr,dc=gov,dc=br
+
 #Usuário de teste
 USUARIO_TESTE=spa2.teste
 SENHA_TESTE=123456

--- a/backend/ldap-seeds.ldif
+++ b/backend/ldap-seeds.ldif
@@ -10,299 +10,39 @@ objectClass: organizationalUnit
 ou: usuarios
 description:: TGlzdGEgZGUgdXN1w6FyaW9zCg==
 
-dn: cn=rh,ou=grupos,dc=cmc,dc=pr,dc=gov,dc=br
-objectClass: top
-objectClass: posixGroup
-gidNumber: 10195
-description: Usuarios do RH
-memberUid: gavio.carrilho
-memberUid: diamantino.figueiredo
-memberUid: egas.bogalho
-memberUid: hermesinda.bezerril
-cn: rh
-
-dn: cn=ti,ou=grupos,dc=cmc,dc=pr,dc=gov,dc=br
+dn: cn=dif,ou=grupos,dc=cmc,dc=pr,dc=gov,dc=br
 objectClass: top
 objectClass: posixGroup
 gidNumber: 10196
-description: Usuarios do TI
-memberUid: ismael.semedo
-memberUid: maria.gomez
-memberUid: neusa.fogaca
-memberUid: tiago.boga
-cn: ti
+description:: RGlyZXRvcmlhIGRlIEluZm9ybcOhdGljYQo=
+memberUid: alexandre.odoni
+memberUid: geraldo.wehmhoff
+memberUid: fabio.teixeira
+memberUid: deini.porto
+memberUid: bruno.oliveira
+memberUid: rodrigo.ferraro
+cn: dif
 
-dn: cn=contab,ou=grupos,dc=cmc,dc=pr,dc=gov,dc=br
+dn: cn=desenv,ou=grupos,dc=cmc,dc=pr,dc=gov,dc=br
 objectClass: top
 objectClass: posixGroup
-gidNumber: 10197
-description: Usuarios do RH
-memberUid: uriel.villaverde
-memberUid: xenia.tabosa
-memberUid: adelio.figueiredo
-memberUid: almeno.quinta
-memberUid: daniela.bulhosa
-cn: contab
-
-dn: uid=gavio.carrilho,ou=usuarios,dc=cmc,dc=pr,dc=gov,dc=br
-objectClass: top
-objectClass: person
-objectClass: organizationalPerson
-objectClass: inetOrgPerson
-objectClass: posixAccount
-objectClass: shadowAccount
-uid: gavio.carrilho
-uidNumber: 1025
-gidNumber: 10195
-displayName:: R8OhdmlvIENhcnJpbGhvCg==
-sn: Carrilho
-cn:: R8OhdmlvIENhcnJpbGhvCg==
-givenName:: R8OhdmlvCg==
-mail: gavio.carrilho@cmc.pr.gov.br
-userPassword: {SHA}p4sEDlSko1mcAQQRL6AeSoW20fo=
-shadowLastChange: 18225
-shadowMax: 365
-homeDirectory: /home/gavio.carrilho
-
-dn: uid=diamantino.figueiredo,ou=usuarios,dc=cmc,dc=pr,dc=gov,dc=br
-objectClass: top
-objectClass: person
-objectClass: organizationalPerson
-objectClass: inetOrgPerson
-objectClass: posixAccount
-objectClass: shadowAccount
-uid: diamantino.figueiredo
-uidNumber: 1026
-gidNumber: 10195
-displayName: Diamantino Figueiredo
-sn: Figueiredo
-cn: Diamantino Figueiredo
-givenName: Diamantino
-mail: diamantino.figueiredo@cmc.pr.gov.br
-userPassword: {SHA}p4sEDlSko1mcAQQRL6AeSoW20fo=
-shadowLastChange: 18235
-shadowMax: 365
-homeDirectory: /home/diamantino.figueiredo
-
-dn: uid=egas.bogalho,ou=usuarios,dc=cmc,dc=pr,dc=gov,dc=br
-objectClass: top
-objectClass: person
-objectClass: organizationalPerson
-objectClass: inetOrgPerson
-objectClass: posixAccount
-objectClass: shadowAccount
-uid: egas.bogalho
-uidNumber: 1027
-gidNumber: 10195
-displayName: Egas Bogalho
-sn: Bogalho
-cn: Egas Bogalho
-givenName: Egas
-mail: egas.bogalho@cmc.pr.gov.br
-userPassword: {SHA}p4sEDlSko1mcAQQRL6AeSoW20fo=
-shadowLastChange: 18245
-shadowMax: 365
-homeDirectory: /home/egas.bogalho
-
-dn: uid=hermesinda.bezerril,ou=usuarios,dc=cmc,dc=pr,dc=gov,dc=br
-objectClass: top
-objectClass: person
-objectClass: organizationalPerson
-objectClass: inetOrgPerson
-objectClass: posixAccount
-objectClass: shadowAccount
-uid: hermesinda.bezerril
-uidNumber: 1028
-gidNumber: 10195
-displayName: Hermesinda Bezerril
-sn: Bezerril
-cn: Hermesinda Bezerril
-givenName: Hermesinda
-mail: hermesinda.bezerril@cmc.pr.gov.br
-userPassword: {SHA}p4sEDlSko1mcAQQRL6AeSoW20fo=
-shadowLastChange: 18255
-shadowMax: 365
-homeDirectory: /home/hermesinda.bezerril
-
-dn: uid=ismael.semedo,ou=usuarios,dc=cmc,dc=pr,dc=gov,dc=br
-objectClass: top
-objectClass: person
-objectClass: organizationalPerson
-objectClass: inetOrgPerson
-objectClass: posixAccount
-objectClass: shadowAccount
-uid: ismael.semedo
-uidNumber: 1029
 gidNumber: 10196
-displayName: Ismael Semedo
-sn: Semedo
-cn: Ismael Semedo
-givenName: Ismael
-mail: ismael.semedo@cmc.pr.gov.br
-userPassword: {SHA}p4sEDlSko1mcAQQRL6AeSoW20fo=
-shadowLastChange: 18265
-shadowMax: 365
-homeDirectory: /home/ismael.semedo
+description:: RGl2aXPDo28gZGUgRGVzZW52b2x2aW1lbnRvIGRlIFNpc3RlbWFzCg==
+memberUid: alexandre.odoni
+memberUid: geraldo.wehmhoff
+memberUid: fabio.teixeira
+memberUid: deini.porto
+memberUid: rodrigo.ferraro
+cn: desenv
 
-dn: uid=maria.gomez,ou=usuarios,dc=cmc,dc=pr,dc=gov,dc=br
+dn: cn=suporte,ou=grupos,dc=cmc,dc=pr,dc=gov,dc=br
 objectClass: top
-objectClass: person
-objectClass: organizationalPerson
-objectClass: inetOrgPerson
-objectClass: posixAccount
-objectClass: shadowAccount
-uid: maria.gomez
-uidNumber: 1030
+objectClass: posixGroup
 gidNumber: 10196
-displayName:: TWFyaWEgR8OzbWV6Cg==
-sn:: R8OzbWV6Cg==
-cn:: TWFyaWEgR8OzbWV6Cg==
-givenName: Maria
-mail: maria.gomez@cmc.pr.gov.br
-userPassword: {SHA}p4sEDlSko1mcAQQRL6AeSoW20fo=
-shadowLastChange: 18275
-shadowMax: 365
-homeDirectory: /home/maria.gomez
-
-dn: uid=neusa.fogaca,ou=usuarios,dc=cmc,dc=pr,dc=gov,dc=br
-objectClass: top
-objectClass: person
-objectClass: organizationalPerson
-objectClass: inetOrgPerson
-objectClass: posixAccount
-objectClass: shadowAccount
-uid: neusa.fogaca
-uidNumber: 1031
-gidNumber: 10196
-displayName:: TmV1c2EgRm9nYcOnYQo=
-sn:: Rm9nYcOnYQo=
-cn:: TmV1c2EgRm9nYcOnYQo=
-givenName: Neusa
-mail: neusa.fogaca@cmc.pr.gov.br
-userPassword: {SHA}p4sEDlSko1mcAQQRL6AeSoW20fo=
-shadowLastChange: 18285
-shadowMax: 365
-homeDirectory: /home/neusa.fogaca
-
-dn: uid=tiago.boga,ou=usuarios,dc=cmc,dc=pr,dc=gov,dc=br
-objectClass: top
-objectClass: person
-objectClass: organizationalPerson
-objectClass: inetOrgPerson
-objectClass: posixAccount
-objectClass: shadowAccount
-uid: tiago.boga
-uidNumber: 1032
-gidNumber: 10196
-displayName: Tiago Boga
-sn: Boga
-cn: Tiago Boga
-givenName: Tiago
-mail: tiago.boga@cmc.pr.gov.br
-userPassword: {SHA}p4sEDlSko1mcAQQRL6AeSoW20fo=
-shadowLastChange: 18295
-shadowMax: 365
-homeDirectory: /home/tiago.boga
-
-dn: uid=uriel.villaverde,ou=usuarios,dc=cmc,dc=pr,dc=gov,dc=br
-objectClass: top
-objectClass: person
-objectClass: organizationalPerson
-objectClass: inetOrgPerson
-objectClass: posixAccount
-objectClass: shadowAccount
-uid: uriel.villaverde
-uidNumber: 1033
-gidNumber: 10197
-displayName: Uriel Villaverde
-sn: Villaverde
-cn: Uriel Villaverde
-givenName: Uriel
-mail: uriel.villaverde@cmc.pr.gov.br
-userPassword: {SHA}p4sEDlSko1mcAQQRL6AeSoW20fo=
-shadowLastChange: 18305
-shadowMax: 365
-homeDirectory: /home/uriel.villaverde
-
-dn: uid=xenia.tabosa,ou=usuarios,dc=cmc,dc=pr,dc=gov,dc=br
-objectClass: top
-objectClass: person
-objectClass: organizationalPerson
-objectClass: inetOrgPerson
-objectClass: posixAccount
-objectClass: shadowAccount
-uid: xenia.tabosa
-uidNumber: 1034
-gidNumber: 10197
-displayName:: WMOpbmlhIFRhYm9zYQo=
-sn: Tabosa
-cn:: WMOpbmlhIFRhYm9zYQo=
-givenName:: WMOpbmlhCg==
-mail: xenia.tabosa@cmc.pr.gov.br
-userPassword: {SHA}p4sEDlSko1mcAQQRL6AeSoW20fo=
-shadowLastChange: 18315
-shadowMax: 365
-homeDirectory: /home/xenia.tabosa
-
-dn: uid=adelio.figueiredo,ou=usuarios,dc=cmc,dc=pr,dc=gov,dc=br
-objectClass: top
-objectClass: person
-objectClass: organizationalPerson
-objectClass: inetOrgPerson
-objectClass: posixAccount
-objectClass: shadowAccount
-uid: adelio.figueiredo
-uidNumber: 1035
-gidNumber: 10197
-displayName:: QWTDqWxpbyBGaWd1ZWlyZWRvCg==
-sn: Figueiredo
-cn:: QWTDqWxpbyBGaWd1ZWlyZWRvCg==
-givenName:: QWTDqWxpbwo=
-mail: adelio.figueiredo@cmc.pr.gov.br
-userPassword: {SHA}p4sEDlSko1mcAQQRL6AeSoW20fo=
-shadowLastChange: 18325
-shadowMax: 365
-homeDirectory: /home/adelio.figueiredo
-
-dn: uid=almeno.quinta,ou=usuarios,dc=cmc,dc=pr,dc=gov,dc=br
-objectClass: top
-objectClass: person
-objectClass: organizationalPerson
-objectClass: inetOrgPerson
-objectClass: posixAccount
-objectClass: shadowAccount
-uid: almeno.quinta
-uidNumber: 1036
-gidNumber: 10197
-displayName: Almeno Quinta
-sn: Quinta
-cn: Almeno Quinta
-givenName: Almeno
-mail: almeno.quinta@cmc.pr.gov.br
-userPassword: {SHA}p4sEDlSko1mcAQQRL6AeSoW20fo=
-shadowLastChange: 18335
-shadowMax: 365
-homeDirectory: /home/almeno.quinta
-
-dn: uid=daniela.bulhosa,ou=usuarios,dc=cmc,dc=pr,dc=gov,dc=br
-objectClass: top
-objectClass: person
-objectClass: organizationalPerson
-objectClass: inetOrgPerson
-objectClass: posixAccount
-objectClass: shadowAccount
-uid: daniela.bulhosa
-uidNumber: 1037
-gidNumber: 10197
-displayName: Daniela Bulhosa
-sn: Bulhosa
-cn: Daniela Bulhosa
-givenName: Daniela
-mail: daniela.bulhosa@cmc.pr.gov.br
-userPassword: {SHA}p4sEDlSko1mcAQQRL6AeSoW20fo=
-shadowLastChange: 18345
-shadowMax: 365
-homeDirectory: /home/daniela.bulhosahomeDirectory: /home/daniela.bulhosa
+description:: RGl2aXPDo28gZGUgU3Vwb3J0ZSBlbSBJbmZvcm3DoXRpY2EK
+memberUid: bruno.oliveira
+memberUid: rodrigo.ferraro
+cn: suporte
 
 dn: uid=alexandre.odoni,ou=usuarios,dc=cmc,dc=pr,dc=gov,dc=br
 objectClass: top
@@ -312,14 +52,120 @@ objectClass: inetOrgPerson
 objectClass: posixAccount
 objectClass: shadowAccount
 uid: alexandre.odoni
-uidNumber: 2179
-gidNumber: 10196
+employeeNumber: 2179
+uidNumber: 1025
+gidNumber: 10195
 displayName: Alexandre Odoni
 sn: Odoni
 cn: Alexandre Odoni
-givenName: Alexandre
+givenName: Odoni
 mail: alexandre.odoni@cmc.pr.gov.br
 userPassword: 123456
-shadowLastChange: 18345
+shadowLastChange: 18225
 shadowMax: 365
 homeDirectory: /home/alexandre.odoni
+
+dn: uid=geraldo.wehmhoff,ou=usuarios,dc=cmc,dc=pr,dc=gov,dc=br
+objectClass: top
+objectClass: person
+objectClass: organizationalPerson
+objectClass: inetOrgPerson
+objectClass: posixAccount
+objectClass: shadowAccount
+uid: geraldo.wehmhoff
+employeeNumber: 2159
+uidNumber: 1026
+gidNumber: 10195
+displayName: Geraldo Wehmhoff
+sn: Wehmhoff
+cn: Geraldo Wehmhoff
+givenName: Wehmhoff
+mail: geraldo.wehmhoff@cmc.pr.gov.br
+userPassword: 123456
+shadowLastChange: 18235
+shadowMax: 365
+homeDirectory: /home/geraldo.wehmhoff
+
+dn: uid=fabio.teixeira,ou=usuarios,dc=cmc,dc=pr,dc=gov,dc=br
+objectClass: top
+objectClass: person
+objectClass: organizationalPerson
+objectClass: inetOrgPerson
+objectClass: posixAccount
+objectClass: shadowAccount
+uid: fabio.teixeira
+employeeNumber: 2209
+uidNumber: 1027
+gidNumber: 10195
+displayName: Fabio Teixeira
+sn: Teixeira
+cn: Fabio Teixeira
+givenName: Fabio
+mail: fabio.teixeira@cmc.pr.gov.br
+userPassword: 123456
+shadowLastChange: 18245
+shadowMax: 365
+homeDirectory: /home/fabio.teixeira
+
+dn: uid=deini.porto,ou=usuarios,dc=cmc,dc=pr,dc=gov,dc=br
+objectClass: top
+objectClass: person
+objectClass: organizationalPerson
+objectClass: inetOrgPerson
+objectClass: posixAccount
+objectClass: shadowAccount
+uid: deini.porto
+employeeNumber: 2154
+uidNumber: 1028
+gidNumber: 10195
+displayName: Deini Porto
+sn: Porto
+cn: Deini Porto
+givenName: Deini
+mail: deini.porto@cmc.pr.gov.br
+userPassword: 123456
+shadowLastChange: 18255
+shadowMax: 365
+homeDirectory: /home/deini.porto
+
+dn: uid=bruno.oliveira,ou=usuarios,dc=cmc,dc=pr,dc=gov,dc=br
+objectClass: top
+objectClass: person
+objectClass: organizationalPerson
+objectClass: inetOrgPerson
+objectClass: posixAccount
+objectClass: shadowAccount
+uid: bruno.oliveira
+employeeNumber: 2246
+uidNumber: 1029
+gidNumber: 10196
+displayName: Bruno Oliveira
+sn: Oliveira
+cn: Bruno Oliveira
+givenName: Bruno
+mail: bruno.oliveira@cmc.pr.gov.br
+userPassword: 123456
+shadowLastChange: 18265
+shadowMax: 365
+homeDirectory: /home/bruno.oliveira
+
+dn: uid=rodrigo.ferraro,ou=usuarios,dc=cmc,dc=pr,dc=gov,dc=br
+objectClass: top
+objectClass: person
+objectClass: organizationalPerson
+objectClass: inetOrgPerson
+objectClass: posixAccount
+objectClass: shadowAccount
+uid: rodrigo.ferraro
+employeeNumber: 2180
+uidNumber: 1030
+gidNumber: 10196
+displayName: Rodrigo Ferraro
+sn: Ferraro
+cn: Rodrigo Ferraro
+givenName: Rodrigo
+mail: rodrigo.ferraro@cmc.pr.gov.br
+userPassword: 123456
+shadowLastChange: 18275
+shadowMax: 365
+homeDirectory: /home/rodrigo.ferraro


### PR DESCRIPTION
Todos os antigos usuários foram substituídos por usuários no seed do
banco.

Incluído também o campo employeeNumber com a matrícula do usuário.

Os grupos podem não refletir exatamente as lotações do banco.

Resolves #44